### PR TITLE
Bugfixes

### DIFF
--- a/fifteen.js
+++ b/fifteen.js
@@ -128,9 +128,6 @@ function moveTile(){
         //if Tile still animating, do not move new tile
             return;
         }
-        if(shuffling == false){
-            moving = true;
-        }
 
         var tileID = this.id.substring(4); //gets tile ID number
         console.log(tileID);
@@ -259,6 +256,7 @@ function moveLeft(tile, id, currentPosition){
     document.getElementById('moves').innerHTML = 'Moves: ' + userMoves;
 }
 function animateMove(tile, direction, currentPosition){
+    moving = true;
     var newPosition = currentPosition;
     var sign;
     if(direction == "left" || direction == "up"){

--- a/fifteen.js
+++ b/fifteen.js
@@ -128,7 +128,9 @@ function moveTile(){
         //if Tile still animating, do not move new tile
             return;
         }
-        moving = true;
+        if(shuffling == false){
+            moving = true;
+        }
 
         var tileID = this.id.substring(4); //gets tile ID number
         console.log(tileID);
@@ -293,7 +295,7 @@ function animateMove(tile, direction, currentPosition){
 }
 
 function animateShuffling(){}
-//TODO: shuffle here
+
 const shuffleButton = document.querySelector('#shuffle')
 shuffleButton.addEventListener('click', shufflePieces)
 

--- a/fifteen.js
+++ b/fifteen.js
@@ -6,6 +6,7 @@
 // VERY IMPORTANT: The VALUE is the location on the board
 let tilePlacement = [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15];
 let shuffling = false;
+let moving = false;
 
 // Movement Array represents legal moves for each tile location
 // [ UP, DOWN, RIGHT, LEFT ], 0 = Cannot Move, 1 = Can move
@@ -123,6 +124,12 @@ function moveTile(){
     // Determine whether the selected Tile can be moved
     // First check if Tile has the .moveablePiece class
     if(this.classList.contains("moveablePiece")){ 
+        if(moving == true && shuffling == false){ 
+        //if Tile still animating, do not move new tile
+            return;
+        }
+        moving = true;
+
         var tileID = this.id.substring(4); //gets tile ID number
         console.log(tileID);
         var ID = parseInt(tileID); //parses as integer
@@ -266,6 +273,7 @@ function animateMove(tile, direction, currentPosition){
 
     function animate(){
         if(position == newPosition){
+            moving = false;
             clearInterval(animate);
         }
         else{
@@ -283,6 +291,7 @@ function animateMove(tile, direction, currentPosition){
         }
     }
 }
+
 function animateShuffling(){}
 //TODO: shuffle here
 const shuffleButton = document.querySelector('#shuffle')

--- a/fifteen.js
+++ b/fifteen.js
@@ -257,6 +257,7 @@ function moveLeft(tile, id, currentPosition){
 }
 function animateMove(tile, direction, currentPosition){
     moving = true;
+    shuffleButton.disabled = true;
     var newPosition = currentPosition;
     var sign;
     if(direction == "left" || direction == "up"){
@@ -274,6 +275,7 @@ function animateMove(tile, direction, currentPosition){
     function animate(){
         if(position == newPosition){
             moving = false;
+            shuffleButton.disabled = false;
             clearInterval(animate);
         }
         else{


### PR DESCRIPTION
Fixed bugs with tile animations: 
clicking on movable tiles in quick succession breaking tile positioning -> don't allow a new tile to move while one is still moving
shuffling while a tile is moving breaking tile positioning -> disable shuffle button while a tile is moving